### PR TITLE
Hardcode the mdbook version to  0.4.52

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN cargo install \
     flip-link \
     elf2uf2-rs \
     rustlings@${RUSTLINGS_VERSION} \
-    mdbook
+    mdbook@0.4.52
 
 # Install linting, formatting, and inspection tools
 RUN rustup component add \


### PR DESCRIPTION
This fixes the error:
```
error: cannot install package `mdbook 0.5.2`, it requires rustc 1.88.0 or newer, while the currently active rustc version is 1.85.0
```
